### PR TITLE
fix: remove console.log on request

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -189,7 +189,6 @@ class TuyaOpenApiClient {
     }
     const contentHash = crypto.createHash('sha256').update(JSON.stringify(body)).digest('hex');
     const stringToSign = [method, contentHash, '', decodeURIComponent(url)].join('\n');
-    console.log(stringToSign)
     const signStr = this.accessKey + accessToken + t + stringToSign;
     return {
       t,


### PR DESCRIPTION
I don't know if it was on purpose but it probably better to prevents unwanted logs