### PR TITLE
Fixed URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.2.0](https://github.com/tuya/tuya-connector-nodejs/compare/v2.1.2...v2.2.0) (2022-04-20)
+
+
+### Features
+
+* **enum:** add TuyaDataCenter enum ([954ddf8](https://github.com/tuya/tuya-connector-nodejs/commit/954ddf805bd6c7f42c3429f5a97253b6874dcdae))
+
+
+### Bug Fixes
+
+* **bugfix:** fixed new API version in request URLs ([d8dde15](https://github.com/tuya/tuya-connector-nodejs/commit/d8dde15af60a42fe7b518644caacdc7ce6bc526a))
+
 ### [2.1.2](https://github.com/tuya/tuya-connector-nodejs/compare/v2.1.1...v2.1.2) (2021-09-15)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuya/tuya-connector-nodejs",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "tuya openapi nodejs sdk",
   "main": "lib/index.js",
   "license": "MIT",

--- a/src/interfaces/DataCenter.ts
+++ b/src/interfaces/DataCenter.ts
@@ -1,0 +1,10 @@
+enum TuyaDataCenter {
+  CHINA = 'https://openapi.tuyacn.com',
+  WESTERN_AMERICA = 'https://openapi.tuyaus.com',
+  EASTERN_AMERICA = 'https://openapi-ueaz.tuyaus.com',
+  CENTRAL_EUROPE = 'https://openapi.tuyaeu.com',
+  WESTERN_EUROPE = 'https://openapi-weaz.tuyaeu.com',
+  INDIA = 'https://openapi.tuyain.com',
+}
+
+export default TuyaDataCenter;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,6 @@
-export * from './tokenStore';
 export * from './context';
+export { default as TuyaDataCenter } from './DataCenter';
 export * from './request';
+export * from './tokenStore';
+
+

--- a/src/service/device/device.ts
+++ b/src/service/device/device.ts
@@ -7,45 +7,46 @@ interface DeviceServiceDetailParam {
 
 interface DeviceServiceDetailResult {
   id: string;
-  name: string;
-  uid: string;
-  local_key: string;
+  gateway_id: string;
+  node_id: string;
+  uuid: string;
   category: string;
+  category_name: string;
+  name: string;
   product_id: string;
   product_name: string;
+  local_key: string;
   sub: boolean;
-  uuid: string;
   asset_id: string;
-  online: boolean;
-  active_time: number;
-  icon: string;
+  owner_id: string;
   ip: string;
+  lon: string;
+  lat: string;
+  model: string;
+  time_zone: string;
+  active_time: number;
+  update_time: number;
+  create_time: number;
+  online: boolean;
+  icon: string;
 }
 
 interface DeviceServiceListParam {
+  source_type?: string;
+  source_id?: string;
   device_ids?: string[];
+  name?: string;
+  category?: string;
+  product_id?: string;
+  last_row_key?: string;
+  page_size?: number;
 }
 
 interface DeviceServiceListResult {
-  total: number;
   has_more: boolean;
-  devices: {
-    id: string;
-    uid: string;
-    local_key: string;
-    category: string;
-    product_id: string;
-    sub: boolean;
-    uuid: string;
-    asset_id: string;
-    online: boolean;
-    name: string;
-    ip: string;
-    time_zone: string;
-    create_time: number;
-    update_time: number;
-    active_time: number;
-  }[];
+  list: DeviceServiceDetailResult[];
+  last_row_key: string;
+  total: number;
 }
 
 interface DeviceServiceResetParam {
@@ -95,9 +96,20 @@ interface DeviceServiceChangeFreezeStateParam {
 
 interface DeviceServiceAssetDevicesParam {
   asset_id: string;
+  last_row_key?: string;
+  page_size?: number;
 }
+
 interface DeviceServiceAssetDevicesResult {
-  id: string;
+  list: {
+    device_id: string;
+    asset_id: string;
+    asset_name: string;
+  }[];
+  last_row_key: string;
+  total_size: number;
+  page_size: number;
+  has_next: boolean;
 }
 
 class TuyaOpenApiDeviceService {
@@ -109,7 +121,7 @@ class TuyaOpenApiDeviceService {
 
   async detail(param: DeviceServiceDetailParam): Promise<TuyaResponse<DeviceServiceDetailResult>> {
     const res = await this.client.request<DeviceServiceDetailResult>({
-      path: `/v1.0/iot-03/devices/${param.device_id}`,
+      path: `/v1.1/iot-03/devices/${param.device_id}`,
       method: 'GET',
     });
     return res.data;
@@ -117,9 +129,12 @@ class TuyaOpenApiDeviceService {
 
   async list(param?: DeviceServiceListParam): Promise<TuyaResponse<DeviceServiceListResult>> {
     const res = await this.client.request<DeviceServiceListResult>({
-      path: `/v1.0/iot-03/devices`,
+      path: `/v1.2/iot-03/devices`,
       method: 'GET',
-      query: param,
+      query: {
+        ...param,
+        device_ids: param?.device_ids?.join(',')
+      },
     });
     return res.data;
   }
@@ -194,16 +209,34 @@ class TuyaOpenApiDeviceService {
   }
 
   async assetDevices(param: DeviceServiceAssetDevicesParam): Promise<TuyaResponse<DeviceServiceAssetDevicesResult[]>> {
-
     const res = await this.client.request<DeviceServiceAssetDevicesResult[]>({
-      path: `/v1.0/iot-03/assets/${param.asset_id}/devices`,
+      path: `/v1.0/iot-02/assets/${param.asset_id}/devices`,
       method: 'GET',
+      query: {
+        last_row_key: param.last_row_key,
+        page_size: param.page_size
+      }
     });
     return res.data;
   }
 }
 
 export {
-  TuyaOpenApiDeviceService
-}
+  TuyaOpenApiDeviceService,
+  DeviceServiceDetailParam,
+  DeviceServiceDetailResult,
+  DeviceServiceListParam,
+  DeviceServiceListResult,
+  DeviceServiceResetParam,
+  DeviceServiceDeleteParam,
+  DeviceServiceDeleteBatchParam,
+  DeviceServiceSubDeviceParam,
+  DeviceServiceSubDeviceResult,
+  DeviceServiceChangeNameParam,
+  DeviceServiceFreezeStateParam,
+  DeviceServiceFreezeStateResult,
+  DeviceServiceChangeFreezeStateParam,
+  DeviceServiceAssetDevicesParam,
+  DeviceServiceAssetDevicesResult,
+};
 export default TuyaOpenApiDeviceService;

--- a/src/service/device/functions.ts
+++ b/src/service/device/functions.ts
@@ -36,27 +36,28 @@ interface DeviceFunctionServiceSpecificationParam {
   device_id: string;
 }
 
+type StatusFunctionsType = {
+  code: string;
+  type: string;
+  name: string;
+  values: string;
+  lang_config: {[key: string]: string};
+}
+
 interface DeviceFunctionServiceSpecificationResult {
   category: string;
-  functions: {
-    code: string;
-    type: string;
-    values: string;
-  }[];
-  status: {
-    code: string;
-    type: string;
-    values: string;
-  }[];
+  status: StatusFunctionsType[];
+  functions: StatusFunctionsType[];
 }
+
+type ObjectType = { [key: string]: string | number | boolean; };
 
 interface DeviceFunctionServiceCommandParam {
   device_id: string;
   commands: {
     code: string;
-    value: string | boolean | number;
+    value: string | boolean | number | ObjectType;
   }[];
-
 }
 
 
@@ -85,7 +86,7 @@ class TuyaOpenApiDeviceFunctionService {
 
   async specification(param: DeviceFunctionServiceSpecificationParam): Promise<TuyaResponse<DeviceFunctionServiceSpecificationResult>> {
     const res = await this.client.request<DeviceFunctionServiceSpecificationResult>({
-      path: `/v1.0/iot-03/devices/${param.device_id}/specification`,
+      path: `/v1.2/iot-03/devices/${param.device_id}/specification`,
       method: 'GET',
     });
     return res.data;
@@ -94,7 +95,10 @@ class TuyaOpenApiDeviceFunctionService {
   async command(param: DeviceFunctionServiceCommandParam): Promise<TuyaResponse<boolean>> {
     const res = await this.client.request<boolean>({
       path: `/v1.0/iot-03/devices/${param.device_id}/commands`,
-      method: 'GET',
+      method: 'POST',
+      body : {
+        commands: param.commands
+      }
     });
     return res.data;
   }
@@ -102,6 +106,13 @@ class TuyaOpenApiDeviceFunctionService {
 }
 
 export {
-  TuyaOpenApiDeviceFunctionService
-}
+  TuyaOpenApiDeviceFunctionService,
+  DeviceFunctionServiceCategoriesParam,
+  DeviceFunctionServiceCategoriesResult,
+  DeviceFunctionServiceDeviceParam,
+  DeviceFunctionServiceDeviceResult,
+  DeviceFunctionServiceSpecificationParam,
+  DeviceFunctionServiceSpecificationResult,
+  DeviceFunctionServiceCommandParam,
+};
 export default TuyaOpenApiDeviceFunctionService;

--- a/src/service/device/index.ts
+++ b/src/service/device/index.ts
@@ -1,5 +1,6 @@
-export * from './device';
-export * from './functions';
+export { TuyaOpenApiDeviceService } from './device';
+export { TuyaOpenApiDeviceFunctionService } from './functions';
 export * from './logs';
 export * from './registration';
-export * from './status';
+export { TuyaOpenApiDeviceStatusService } from './status';
+

--- a/src/service/device/status.ts
+++ b/src/service/device/status.ts
@@ -30,8 +30,8 @@ class TuyaOpenApiDeviceStatusService {
     this.client = client;
   }
 
-  async status(param: DeviceStatusServiceStatusParam): Promise<TuyaResponse<DeviceStatusServiceStatusResult>> {
-    const res = await this.client.request<DeviceStatusServiceStatusResult>({
+  async status(param: DeviceStatusServiceStatusParam): Promise<TuyaResponse<DeviceStatusServiceStatusResult[]>> {
+    const res = await this.client.request<DeviceStatusServiceStatusResult[]>({
       path: `/v1.0/iot-03/devices/${param.device_id}/status`,
       method: 'GET',
     });
@@ -49,6 +49,10 @@ class TuyaOpenApiDeviceStatusService {
 }
 
 export {
-  TuyaOpenApiDeviceStatusService
-}
+  TuyaOpenApiDeviceStatusService,
+  DeviceStatusServiceStatusParam,
+  DeviceStatusServiceStatusResult,
+  DeviceStatusServiceStatusListParam,
+  DeviceStatusServiceStatusListResult
+};
 export default TuyaOpenApiDeviceStatusService;

--- a/test/utils/axiosMock.ts
+++ b/test/utils/axiosMock.ts
@@ -255,7 +255,30 @@ axiosMock.onPost(/\/v1.0\/iot-02\/assets/).reply(200, {
   });
 
 
-  axiosMock.onGet(/\/v1.0\/iot-03\/devices\/mock-id/).reply(200, {
+  axiosMock.onGet(/\/v1.1\/iot-03\/devices\/mock-id/).reply(200, {
+    "success": true,
+    "result": {
+      "active_time": 1589505938,
+      "category": "qt",
+      "create_time": 1560827137,
+      "icon": "smart/icon/15402589135gknz23xajb_0.png",
+      "id": "60613135b121cddc294****",
+      "ip": "120.198.****.****",
+      "local_key": "3a9b50126fe473****",
+      "name": "体脂秤",
+      "online": true,
+      "asset_id": "1070****",
+      "product_id": "g0er6hSKgMqr****",
+      "product_name": "Wifi scales_OEM",
+      "sub": false,
+      "time_zone": "+08:00",
+      "uid": "ay157896239864843g****",
+      "update_time": 1589764585,
+      "uuid": "60613135b23cddc294****"
+    }
+  });
+
+  axiosMock.onGet(/\/v1.2\/iot-03\/devices\?device_ids=mock-id/).reply(200, {
     "success": true,
     "result": {
       "active_time": 1589505938,
@@ -424,7 +447,7 @@ axiosMock.onPost(/\/v1.0\/iot-02\/assets/).reply(200, {
         ]
     }
   });
-  axiosMock.onGet(/\/v1.0\/iot-03\/devices\/mock-id\/specification/).reply(200, {
+  axiosMock.onGet(/\/v1.2\/iot-03\/devices\/mock-id\/specification/).reply(200, {
        "success":true,
     "t":1571201730542,
     "result":{
@@ -476,7 +499,7 @@ axiosMock.onPost(/\/v1.0\/iot-02\/assets/).reply(200, {
     }
   });
 
-  axiosMock.onPut(/\/v1.0\/iot-03\/devices\/mock-id\/commands/).reply(200, {
+  axiosMock.onPost(/\/v1.0\/iot-03\/devices\/mock-id\/commands/).reply(200, {
     "success":true,
     "t":1551851043862,
     "result":true
@@ -568,4 +591,5 @@ axiosMock.onPost(/\/v1.0\/iot-02\/assets/).reply(200, {
 export {
   axios,
   axiosMock,
-}
+};
+


### PR DESCRIPTION
Recently, Tuya changed their API and the old request URLs don't work anymore. I fixed all invalid URLs I found (with their respective tests).

Also, I added an enum called TuyaDataCenter for prevent baseURL harcoding errors.